### PR TITLE
Replace synchronized batch-norm with nvidia-apex implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *__pycache__/
 *build
+./data/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *__pycache__/
 *build
-./data/*
+data/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*__pycache__/
+*build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *__pycache__/
 *build
 data/*
+checkpoints
+logs
+result

--- a/data/rvc_devkit
+++ b/data/rvc_devkit
@@ -1,1 +1,0 @@
-/lhome/nhansel/data/rvc_devkit/

--- a/data/rvc_devkit
+++ b/data/rvc_devkit
@@ -1,0 +1,1 @@
+/lhome/nhansel/data/rvc_devkit/

--- a/dataloader/dataset.py
+++ b/dataloader/dataset.py
@@ -9,6 +9,8 @@ import random
 from struct import unpack
 import re
 import sys
+import os
+
 def readPFM(file): 
     with open(file, "rb") as f:
             # Line 1: PF=>RGB (3 channels), Pf=>Greyscale (1 channel)
@@ -187,6 +189,8 @@ def load_kitti_data(file_path, current_file):
     temp_data[6, :, :] = temp / 256.
     
     return temp_data
+
+
 def load_kitti2015_data(file_path, current_file):
     """ load current file from the list"""
     filename = file_path + 'image_2/' + current_file[0: len(current_file) - 1]
@@ -228,6 +232,46 @@ def load_kitti2015_data(file_path, current_file):
     return temp_data
 
 
+def load_rvc_data(file_path, current_file):
+    """ load current file from the list"""
+    filename = os.path.join(file_path, current_file[0: len(current_file) - 1], "im0.png")
+    left = Image.open(filename)
+    filename = os.path.join(file_path, current_file[0: len(current_file) - 1], "im1.png")
+    right = Image.open(filename)
+    filename = os.path.join(file_path, current_file[0: len(current_file) - 1], "disp0GT.pfm")
+
+    disp_left = Image.open(filename)
+    temp = np.asarray(disp_left)
+    size = np.shape(left)
+
+    height = size[0]
+    width = size[1]
+    temp_data = np.zeros([8, height, width], 'float32')
+    left = np.asarray(left)
+    right = np.asarray(right)
+    disp_left = np.asarray(disp_left)
+    r = left[:, :, 0]
+    g = left[:, :, 1]
+    b = left[:, :, 2]
+ 
+    temp_data[0, :, :] = (r - np.mean(r[:])) / np.std(r[:])
+    temp_data[1, :, :] = (g - np.mean(g[:])) / np.std(g[:])
+    temp_data[2, :, :] = (b - np.mean(b[:])) / np.std(b[:])
+    r = right[:, :, 0]
+    g = right[:, :, 1]
+    b = right[:, :, 2]	
+
+    temp_data[3, :, :] = (r - np.mean(r[:])) / np.std(r[:])
+    temp_data[4, :, :] = (g - np.mean(g[:])) / np.std(g[:])
+    temp_data[5, :, :] = (b - np.mean(b[:])) / np.std(b[:])
+    temp_data[6: 7, :, :] = width * 2
+    temp_data[6, :, :] = disp_left[:, :]
+    temp = temp_data[6, :, :]
+    temp[temp < 0.1] = width * 2 * 256
+    temp_data[6, :, :] = temp / 256.
+    
+    return temp_data
+
 
 class DatasetFromList(data.Dataset): 
     def __init__(self, data_path, file_list, crop_size=[256, 256], training=True, left_right=False, kitti=False, kitti2015=False, shift=0):
@@ -246,13 +290,16 @@ class DatasetFromList(data.Dataset):
 
     def __getitem__(self, index):
     #    print self.file_list[index]
-        if self.kitti: #load kitti dataset
-            temp_data = load_kitti_data(self.data_path, self.file_list[index])
-        elif self.kitti2015: #load kitti2015 dataset
-            temp_data = load_kitti2015_data(self.data_path, self.file_list[index])
-        else: #load scene flow dataset
-            temp_data = load_data(self.data_path, self.file_list[index])
-#        temp_data = load_data(self.data_path,self.file_list[index])
+        if True:
+            temp_data = load_rvc_data(self.data_path, self.file_list[index])
+        else:
+            if self.kitti: #load kitti dataset
+                temp_data = load_kitti_data(self.data_path, self.file_list[index])
+            elif self.kitti2015: #load kitti2015 dataset
+                temp_data = load_kitti2015_data(self.data_path, self.file_list[index])
+            else: #load scene flow dataset
+                temp_data = load_data(self.data_path, self.file_list[index])
+    #        temp_data = load_data(self.data_path,self.file_list[index])
         if self.training:
             input1, input2, target = train_transform(temp_data, self.crop_height, self.crop_width, self.left_right, self.shift)
             return input1, input2, target

--- a/dataloader/dataset.py
+++ b/dataloader/dataset.py
@@ -240,7 +240,7 @@ def load_rvc_data(file_path, current_file):
     right = Image.open(filename)
     filename = os.path.join(file_path, current_file[0: len(current_file) - 1], "disp0GT.pfm")
 
-    disp_left = Image.open(filename)
+    disp_left, height, width = readPFM(filename)
     temp = np.asarray(disp_left)
     size = np.shape(left)
 

--- a/evaluation.sh
+++ b/evaluation.sh
@@ -1,3 +1,14 @@
+CUDA_VISIBLE_DEVICES=0 python evaluation.py --crop_height=480 \
+                                            --crop_width=960 \
+                                            --max_disp=192 \
+                                            --data_path='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/training/' \
+                                            --test_list='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/lists/training_eth3d.list' \
+                                            --save_path='./result/' \
+                                            --kitti2015=1 \
+                                            --threshold=3.0 \
+                                            --resume='./checkpoints/kitti2015_final.pth'
+exit
+
 CUDA_VISIBLE_DEVICES=0 python evaluation.py --crop_height=384 \
                                             --crop_width=1248 \
                                             --max_disp=192 \

--- a/evaluation.sh
+++ b/evaluation.sh
@@ -1,12 +1,13 @@
 CUDA_VISIBLE_DEVICES=0 python evaluation.py --crop_height=384 \
-                  --crop_width=1248 \
-                  --max_disp=192 \
-                  --data_path='/ssd1/zhangfeihu/data/kitti2015/training/' \
-                  --test_list='lists/kitti2015_train.list' \
-                  --save_path='./result/' \
-                  --resume='./checkpoint/kitti2015_final.pth' \
-                  --threshold=3.0 \
-                  --kitti2015=1
+                                            --crop_width=1248 \
+                                            --max_disp=192 \
+                                            --data_path='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/training/' \
+                                            --test_list='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/lists/training_kitti.list' \
+                                            --save_path='./result/' \
+                                            --kitti2015=1 \
+                                            --threshold=3.0 \
+                                            --resume='./checkpoints/kitti2015_final.pth'
+
 # 2>&1 |tee logs/log_evaluation.txt
 exit
 CUDA_VISIBLE_DEVICES=0 python evaluation.py --crop_height=384 \

--- a/evaluation.sh
+++ b/evaluation.sh
@@ -1,12 +1,13 @@
 CUDA_VISIBLE_DEVICES=0 python evaluation.py --crop_height=480 \
                                             --crop_width=960 \
                                             --max_disp=192 \
-                                            --data_path='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/training/' \
-                                            --test_list='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/lists/training_eth3d.list' \
+                                            --data_path='./data/rvc_devkit/stereo/datasets_middlebury2014/eval/' \
+                                            --test_list='./data/rvc_devkit/stereo/datasets_middlebury2014/lists/eval.list' \
                                             --save_path='./result/' \
                                             --kitti2015=1 \
                                             --threshold=3.0 \
-                                            --resume='./checkpoints/kitti2015_final.pth'
+                                            # --resume='./checkpoints/rvc.pth'
+                                            --resume='./checkpoints/sceneflow_epoch_10.pth'
 exit
 
 CUDA_VISIBLE_DEVICES=0 python evaluation.py --crop_height=384 \

--- a/predict.py
+++ b/predict.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import argparse
+import scipy
 import skimage
 import skimage.io
 import skimage.transform
@@ -78,19 +79,36 @@ if opt.resume:
 def test_transform(temp_data, crop_height, crop_width):
     _, h, w=np.shape(temp_data)
 
-    if h <= crop_height and w <= crop_width:
-        temp = temp_data
-        temp_data = np.zeros([6, crop_height, crop_width], 'float32')
-        temp_data[:, crop_height - h: crop_height, crop_width - w: crop_width] = temp
-    else:
-        start_x = int((w - crop_width) / 2)
-        start_y = int((h - crop_height) / 2)
-        temp_data = temp_data[:, start_y: start_y + crop_height, start_x: start_x + crop_width]
+    if h != crop_height or w != crop_width:
+        zoom_h = crop_height / h
+        zoom_w = crop_width / w
+        
+        temp_data = scipy.ndimage.zoom(temp_data, (1, zoom_h, zoom_w), order=1)
+
+        h = crop_height
+        w = crop_width
+
+    # if h <= crop_height and w <= crop_width:
+    #     temp = temp_data
+    #     temp_data = np.zeros([6, crop_height, crop_width], 'float32')
+    #     temp_data[:, crop_height - h: crop_height, crop_width - w: crop_width] = temp
+    # else:
+    #     start_x = int((w - crop_width) / 2)
+    #     start_y = int((h - crop_height) / 2)
+    #     temp_data = temp_data[:, start_y: start_y + crop_height, start_x: start_x + crop_width]
     left = np.ones([1, 3,crop_height,crop_width],'float32')
     left[0, :, :, :] = temp_data[0: 3, :, :]
     right = np.ones([1, 3, crop_height, crop_width], 'float32')
     right[0, :, :, :] = temp_data[3: 6, :, :]
     return torch.from_numpy(left).float(), torch.from_numpy(right).float(), h, w
+
+def test_post_processing(pred, target_height, target_width):
+    zoom_h = target_height / pred.shape[0]
+    zoom_w = target_width / pred.shape[1]
+        
+    pred = scipy.ndimage.zoom(pred, (zoom_h, zoom_w), order=1)
+    return pred
+
 
 def load_data(leftname, rightname):
     left = Image.open(leftname)
@@ -114,12 +132,12 @@ def load_data(leftname, rightname):
     temp_data[3, :, :] = (r - np.mean(r[:])) / np.std(r[:])
     temp_data[4, :, :] = (g - np.mean(g[:])) / np.std(g[:])
     temp_data[5, :, :] = (b - np.mean(b[:])) / np.std(b[:])
-    return temp_data
+    return temp_data, size
 
 def test(leftname, rightname, savename):
   #  count=0
-    
-    input1, input2, height, width = test_transform(load_data(leftname, rightname), opt.crop_height, opt.crop_width)
+    data, size = load_data(leftname, rightname)
+    input1, input2, height, width = test_transform(data, opt.crop_height, opt.crop_width)
 
     
     input1 = Variable(input1, requires_grad = False)
@@ -138,8 +156,13 @@ def test(leftname, rightname, savename):
         temp = temp[0, opt.crop_height - height: opt.crop_height, opt.crop_width - width: opt.crop_width]
     else:
         temp = temp[0, :, :]
+    
+    # rescale to target resolution
+    temp = test_post_processing(temp, size[0], size[1])
 
+    # write image
     imageio.imwrite(savename, (temp * 256).astype('uint16'))
+
 
 
    
@@ -163,4 +186,5 @@ if __name__ == "__main__":
 
         savename = opt.save_path + current_file[0: len(current_file) - 1] + ".png"
         test(leftname, rightname, savename)
+        
 

--- a/predict.py
+++ b/predict.py
@@ -3,6 +3,7 @@ import argparse
 import skimage
 import skimage.io
 import skimage.transform
+import imageio
 from PIL import Image
 from math import log10
 #from GCNet.modules.GCNet import L1Loss
@@ -19,6 +20,8 @@ from torch.utils.data import DataLoader
 #from models.GANet_deep import GANet
 from dataloader.data import get_test_set
 import numpy as np
+
+import matplotlib.pyplot as plt
 
 # Training settings
 parser = argparse.ArgumentParser(description='PyTorch GANet Example')
@@ -135,7 +138,9 @@ def test(leftname, rightname, savename):
         temp = temp[0, opt.crop_height - height: opt.crop_height, opt.crop_width - width: opt.crop_width]
     else:
         temp = temp[0, :, :]
-    skimage.io.imsave(savename, (temp * 256).astype('uint16'))
+
+    imageio.imwrite(savename, (temp * 256).astype('uint16'))
+
 
    
 if __name__ == "__main__":
@@ -145,13 +150,17 @@ if __name__ == "__main__":
     filelist = f.readlines()
     for index in range(len(filelist)):
         current_file = filelist[index]
-        if opt.kitti2015:
-            leftname = file_path + 'image_2/' + current_file[0: len(current_file) - 1]
-            rightname = file_path + 'image_3/' + current_file[0: len(current_file) - 1]
-        if opt.kitti:
-            leftname = file_path + 'colored_0/' + current_file[0: len(current_file) - 1]
-            rightname = file_path + 'colored_1/' + current_file[0: len(current_file) - 1]
+        leftname = os.path.join(file_path, current_file[0: len(current_file) - 1], "im0.png")
+        rightname = os.path.join(file_path, current_file[0: len(current_file) - 1], "im1.png")
+        print(leftname, rightname)
+        
+        # if opt.kitti2015:
+        #     leftname = file_path + 'image_2/' + current_file[0: len(current_file) - 1]
+        #     rightname = file_path + 'image_3/' + current_file[0: len(current_file) - 1]
+        # if opt.kitti:
+        #     leftname = file_path + 'colored_0/' + current_file[0: len(current_file) - 1]
+        #     rightname = file_path + 'colored_1/' + current_file[0: len(current_file) - 1]
 
-        savename = opt.save_path + current_file[0: len(current_file) - 1]
+        savename = opt.save_path + current_file[0: len(current_file) - 1] + ".png"
         test(leftname, rightname, savename)
 

--- a/predict.sh
+++ b/predict.sh
@@ -2,11 +2,13 @@
 python predict.py --crop_height=240 \
                   --crop_width=528 \
                   --max_disp=192 \
-                  --data_path='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/test/' \
-                  --test_list='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/lists/test.list' \
+                  --data_path='./data/rvc_devkit/stereo/datasets_middlebury2014/test/' \
+                  --test_list='./data/rvc_devkit/stereo/datasets_middlebury2014/lists/test.list' \
                   --save_path='./result/' \
                   --kitti2015=1 \
-                  --resume='./checkpoints/kitti2015_final.pth'
+                  --resume='./checkpoints/sceneflow_epoch_10.pth'
+                  # --resume='./checkpoints/kitti2015_final.pth'
+                  # --resume='./checkpoints/rvc.pth'
 exit
 
 python predict.py --crop_height=384 \

--- a/predict.sh
+++ b/predict.sh
@@ -1,12 +1,12 @@
 
-python predict.py --crop_height=384 \
-                  --crop_width=1248 \
+python predict.py --crop_height=240 \
+                  --crop_width=528 \
                   --max_disp=192 \
-                  --data_path='/ssd1/zhangfeihu/data/kitti/2015//testing/' \
-                  --test_list='lists/kitti2015_test.list' \
+                  --data_path='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/test/' \
+                  --test_list='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/lists/test.list' \
                   --save_path='./result/' \
                   --kitti2015=1 \
-                  --resume='./checkpoint/kitti2015_final.pth'
+                  --resume='./checkpoints/kitti2015_final.pth'
 exit
 
 python predict.py --crop_height=384 \

--- a/train.sh
+++ b/train.sh
@@ -1,14 +1,14 @@
-CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python train.py --batchSize=16 \
+CUDA_VISIBLE_DEVICES=0 python train.py --batchSize=1 \
                 --crop_height=240 \
-                --crop_width=528 \
+                --crop_width=480 \
                 --max_disp=192 \
-                --thread=16 \
-                --data_path='/ssd1/zhangfeihu/data/stereo/' \
-                --training_list='lists/sceneflow_train.list' \
-                --save_path='./checkpoint/sceneflow' \
+                --thread=12 \
+                --data_path='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/training/' \
+                --training_list='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/lists/training.list' \
+                --save_path='./checkpoints/rvc' \
                 --resume='' \
                 --model='GANet_deep' \
-                --nEpochs=11 2>&1 |tee logs/log_train_sceneflow.txt
+                --nEpochs=11 2>&1 |tee logs/log_train_rvc.txt
 
 exit
 #Fine tuning for kitti 2015

--- a/train.sh
+++ b/train.sh
@@ -3,8 +3,8 @@ CUDA_VISIBLE_DEVICES=0 python train.py --batchSize=1 \
                 --crop_width=480 \
                 --max_disp=192 \
                 --thread=12 \
-                --data_path='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/training/' \
-                --training_list='/media/nicolas/Data_1/projects/rvc_devkit/stereo/datasets_middlebury2014/lists/training.list' \
+                --data_path='./data/rvc_devkit/stereo/datasets_middlebury2014/training/' \
+                --training_list='./data/rvc_devkit/stereo/datasets_middlebury2014/lists/training.list' \
                 --save_path='./checkpoints/rvc' \
                 --resume='' \
                 --model='GANet_deep' \

--- a/train.sh
+++ b/train.sh
@@ -1,12 +1,12 @@
-CUDA_VISIBLE_DEVICES=0 python train.py --batchSize=1 \
+python train.py --batchSize=2 \
                 --crop_height=240 \
                 --crop_width=480 \
                 --max_disp=192 \
                 --thread=12 \
                 --data_path='./data/rvc_devkit/stereo/datasets_middlebury2014/training/' \
                 --training_list='./data/rvc_devkit/stereo/datasets_middlebury2014/lists/training.list' \
-                --save_path='./checkpoints/rvc' \
-                --resume='' \
+                --save_path='./checkpoints/rvc.pth' \
+                --resume='sceneflow_epoch_10.pth' \
                 --model='GANet_deep' \
                 --nEpochs=11 2>&1 |tee logs/log_train_rvc.txt
 


### PR DESCRIPTION
* GANet's own sync_bn incorrectly uses in-place operations on input tensors with `torch.autograd.Function`. Torch added some additional checks with [commit 3e8d8132638c47d3093cc3d8ca7e47a29a4e5818](https://github.com/pytorch/pytorch/commit/3e8d8132638c47d3093cc3d8ca7e47a29a4e5818) that now throw a runtime error because of this.
As a workaround, every instance of GANet's sync_bn was replaced with the nvidia-apex implementation.

* Added a data directory which is supposed to hold symlinks to the data root directories, so we can have machine-agnostic paths in train.sh, evaluation.sh and predict.sh rather than absolute paths.